### PR TITLE
Adding maven-surefire-plugin 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.19.1</version>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
I add the plugin on pow.xml because I was getting an error `Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project amaro: There are test failures. ` trying to run `mvn install`.